### PR TITLE
Server side localization when request is initiated from client app

### DIFF
--- a/Source/Microsoft.Teams.Apps.EmployeeTraining/ClientApp/src/api/axios-decorator.ts
+++ b/Source/Microsoft.Teams.Apps.EmployeeTraining/ClientApp/src/api/axios-decorator.ts
@@ -6,13 +6,17 @@
 
 import axios, { AxiosResponse, AxiosRequestConfig } from "axios";
 import * as microsoftTeams from "@microsoft/teams-js";
+import i18n from '../i18n';
 
 export class AxiosJWTDecorator {
-	/**
-	* Post data to API
-	* @param  {String} url Resource URI
-	* @param  {Object} data Request body data
-	*/
+    readonly authorizationHeaderKey = "Authorization";
+    readonly acceptLanguageHeaderKey = "Accept-Language";
+
+    /**
+    * Post data to API
+    * @param  {String} url Resource URI
+    * @param  {Object} data Request body data
+    */
     public async post<T = any, R = AxiosResponse<T>>(
         url: string,
         data?: any,
@@ -26,10 +30,10 @@ export class AxiosJWTDecorator {
         }
     }
 
-	/**
-	* Post data to API
-	* @param  {String} url Resource URI
-	*/
+    /**
+    * Post data to API
+    * @param  {String} url Resource URI
+    */
     public async delete<T = any, R = AxiosResponse<T>>(
         url: string,
         config?: AxiosRequestConfig
@@ -42,11 +46,11 @@ export class AxiosJWTDecorator {
         }
     }
 
-	/**
-	* Post data to API
-	* @param  {String} url Resource URI
-	* @param  {Object} data Request body data
-	*/
+    /**
+    * Post data to API
+    * @param  {String} url Resource URI
+    * @param  {Object} data Request body data
+    */
     public async put<T = any, R = AxiosResponse<T>>(
         url: string,
         data?: any,
@@ -78,9 +82,9 @@ export class AxiosJWTDecorator {
         }
     }
 
-	/**
-	* Get data to API
-	*/
+    /**
+    * Get data to API
+    */
     public async get<T = any, R = AxiosResponse<T>>(
         url: string,
         config?: AxiosRequestConfig,
@@ -97,8 +101,8 @@ export class AxiosJWTDecorator {
     }
 
     /**
-	* Get data to API
-	*/
+    * Get data to API
+    */
     public async getCachedData<T = any, R = AxiosResponse<T>>(
         url: string,
         config?: AxiosRequestConfig,
@@ -116,10 +120,10 @@ export class AxiosJWTDecorator {
     }
 
     /**
-	* Handle error occurred during API call.
-	* @param  {Object} error Error response object
-	*/
-    private handleError(error: any):any {
+    * Handle error occurred during API call.
+    * @param  {Object} error Error response object
+    */
+    private handleError(error: any): any {
         if (error.hasOwnProperty("response")) {
             return error.response;
         } else {
@@ -127,33 +131,34 @@ export class AxiosJWTDecorator {
         }
     }
 
-	private async setupAuthorizationHeader(
-		config?: AxiosRequestConfig
-	): Promise<AxiosRequestConfig> {
-		microsoftTeams.initialize();
+    private async setupAuthorizationHeader(
+        config?: AxiosRequestConfig
+    ): Promise<AxiosRequestConfig> {
+        microsoftTeams.initialize();
 
-		return new Promise<AxiosRequestConfig>((resolve, reject) => {
-			const authTokenRequest = {
-				successCallback: (token: string) => {
-					if (!config) {
-						config = axios.defaults;
-					}
-					config.headers["Authorization"] = `Bearer ${token}`;
-					resolve(config);
-				},
-				failureCallback: (error: string) => {
-					// When the getAuthToken function returns a "resourceRequiresConsent" error, 
-					// it means Azure AD needs the user's consent before issuing a token to the app. 
-					// The following code redirects the user to the "Sign in" page where the user can grant the consent. 
-					// Right now, the app redirects to the consent page for any error.
-					console.error("Error from getAuthToken: ", error);
-					window.location.href = "/signin";
-				},
-				resources: []
-			};
-			microsoftTeams.authentication.getAuthToken(authTokenRequest);
-		});
-	}
+        return new Promise<AxiosRequestConfig>((resolve, reject) => {
+            const authTokenRequest = {
+                successCallback: (token: string) => {
+                    if (!config) {
+                        config = axios.defaults;
+                    }
+                    config.headers[this.authorizationHeaderKey] = `Bearer ${token}`;
+                    config.headers[this.acceptLanguageHeaderKey] = i18n.language;
+                    resolve(config);
+                },
+                failureCallback: (error: string) => {
+                    // When the getAuthToken function returns a "resourceRequiresConsent" error, 
+                    // it means Azure AD needs the user's consent before issuing a token to the app. 
+                    // The following code redirects the user to the "Sign in" page where the user can grant the consent. 
+                    // Right now, the app redirects to the consent page for any error.
+                    console.error("Error from getAuthToken: ", error);
+                    window.location.href = "/signin";
+                },
+                resources: []
+            };
+            microsoftTeams.authentication.getAuthToken(authTokenRequest);
+        });
+    }
 }
 
 const axiosJWTDecoratorInstance = new AxiosJWTDecorator();


### PR DESCRIPTION
Issue:
Current template detects locale from bot activity only. In case where card needs to be sent while processing an API request initiated by client app, default culture (from appsettings.json) was getting used.

Fix:
Resolved the issue by checking whether request is initiated from bot
If yes, then get locale from activity object.
If no, check Accept-Language header in request.
Accept-Language header is getting set at client side before sending API request.

Testing and verification:
Done