### PR TITLE
Fixed issue for created by filter not working on tab

### DIFF
--- a/Source/Microsoft.Teams.Apps.EmployeeTraining/ClientApp/src/api/user-events-api.ts
+++ b/Source/Microsoft.Teams.Apps.EmployeeTraining/ClientApp/src/api/user-events-api.ts
@@ -20,6 +20,7 @@ export const getEventsAsync = async (
         searchString: encodeURIComponent(searchString),
         pageCount: pageCount,
         eventSearchType: eventSearchType,
+        createdByFilter: createdByFilter,
         categoryFilter: categoryFilter,
         sortBy: sortByFilter
     };


### PR DESCRIPTION
Tab grid is not getting filtered with created by filtered.

