### PR TITLE
Fix encoding issue in export to CSV

### DIFF
--- a/Source/Microsoft.Teams.Apps.EmployeeTraining/ClientApp/src/components/manage-events/manage-events.tsx
+++ b/Source/Microsoft.Teams.Apps.EmployeeTraining/ClientApp/src/components/manage-events/manage-events.tsx
@@ -430,7 +430,7 @@ class ManageEvents extends React.Component<IManageEventsProps, IManageEventsStat
         let response = await exportEventDetailsToCSV(this.teamId, eventId);
 
         if (response.status === ResponseStatus.OK) {
-            const url = window.URL.createObjectURL(new Blob([response.data]));
+            const url = window.URL.createObjectURL(new Blob(["\ufeff", response.data], {type: 'text/csv;charset=utf-8'}));
             const downloadLink = document.createElement('a');
             downloadLink.href = url;
             downloadLink.setAttribute('download', `${eventName}.csv`);


### PR DESCRIPTION
Fix #25
Workaround: add BOM \ufeff at the beginning. Without that the Excel is unable to understand the file codepage correctly.  